### PR TITLE
Remove unnecessary todo comments

### DIFF
--- a/single_flight.ts
+++ b/single_flight.ts
@@ -47,7 +47,6 @@ export class SingleFlight {
   }
 
   public Forget(key: KeyType) {
-    // TODO: lock
     this.waitCalls.set(key, {
       firstCall: false,
       resolvers: [],
@@ -58,7 +57,6 @@ export class SingleFlight {
     if (!ok && this.waitCalls.has(key)) {
       throw Error(`Failed to remove key(= ${key.toString()})`);
     }
-    // TODO: unlock
   }
 
   private getWaitCall(key: KeyType): Call {

--- a/single_flight.ts
+++ b/single_flight.ts
@@ -19,11 +19,9 @@ export class SingleFlight {
   public async Do<T>(key: KeyType, func: Func): Promise<T> {
     return await (new Promise<T>(
       (resolve, reject) => {
-        // TODO: lock
         const wc = this.getWaitCall(key);
         if (wc.forgotten) {
           this.waitCalls.delete(key);
-          // TODO: unlock
           reject(`The key(= ${key.toString()}) is already removed`);
           return;
         }
@@ -33,20 +31,15 @@ export class SingleFlight {
         wc.resolvers.push(resolve);
         wc.rejecters.push(reject);
         this.waitCalls.set(key, wc);
-        // TODO: unlock
 
         if (isFirst) {
           Promise.resolve()
             .then(() => func())
             .then((res) => {
-              // TODO: lock
               this.getWaitCall(key).resolvers.forEach((resolve) => resolve(res));
-              // TODO: unlock
             })
             .catch((err) => {
-              // TODO: lock
               this.getWaitCall(key).rejecters.forEach((reject) => reject(err));
-              // TODO: unlock
             });
         }
       }


### PR DESCRIPTION
web worker などで並列処理する場合 lock 機構が必要
しかし、そもそも別々の web worker から同一の instance を参照できない

通常の環境では lock 機構は必要ないのでコメントは削除した